### PR TITLE
Possibility to use existing connection

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,17 @@ You can build your MongoDB connection url passing an object with the following p
 Or just the url:
 
   * `url` MongoDB connection url (comma separated list of urls for replica set)
+  
+It is also possible to pass instances of select node-mongodb-native classes, thus permitting the usage of existing connections
+or server configurations.
+
+Using an existing connection:
+
+  * `handle` Existing connection/database reference (instance of mongodb.Db)
+  
+Or with a server configuration:
+
+  * `serverConfig` Existing server configuration (may be an instance of either mongodb.Server, mongodb.ServerPair, mongodb.ServerCluster, mongodb.ReplSetServers) - review node-mongodb-native docs.
 
 Other options:
 
@@ -88,9 +99,3 @@ Or some combination:
         port: [27017, 27017, 27018]
       })
     }
-
-## test
-
-To run the tests:
-
-    node test

--- a/lib/connect-mongodb.js
+++ b/lib/connect-mongodb.js
@@ -24,8 +24,12 @@ var Store = require('connect').session.Store,
           password = options.password || '',
           userpass = '',
           i, len;
-
-      if ((username !== '' && password === '') || (password !== '' && username === '')) {
+      
+      if(typeof(username) !== 'string') throw Error('Username must be a string');
+      
+      if(typeof(password) !== 'string') throw Error('Password must be a string');
+      
+      if ((!username && password) || (!password && username)) {
         throw Error('Need both username and password to make an auth connection.');
       } else if (username !== '') {
         userpass = username + ':' + password + '@';

--- a/lib/connect-mongodb.js
+++ b/lib/connect-mongodb.js
@@ -18,8 +18,8 @@ var Store = require('connect').session.Store,
 
     getConnectionURL = function (options) {
       var url = '',
-          hosts = (Array.isArray(options.host) ? options.host : [options.host]) || defaults.host,
-          ports = (Array.isArray(options.port) ? options.port : [options.port]) || defaults.port,
+          hosts = (!Array.isArray(options.host) && options.host ? [options.host] : options.host) || [defaults.host],
+          ports = (!Array.isArray(options.port) && options.port ? [options.port] : options.port) || [defaults.port],
           username = options.username || '',
           password = options.password || '',
           userpass = '',

--- a/lib/connect-mongodb.js
+++ b/lib/connect-mongodb.js
@@ -10,7 +10,7 @@ var Store = require('connect').session.Store,
 
     _collection = null,
     _default = function (callback) {
-      callback = callback || function () { };
+      callback = typeof(callback) === 'function' ? callback : function () { };
       return callback;
     },
 
@@ -180,7 +180,7 @@ MONGOSTORE.prototype.__proto__ = Store.prototype;
  */
 
 MONGOSTORE.prototype.get = function (sid, cb) {
-  _default(cb);
+  cb = _default(cb);
   _collection.findOne({_id: sid}, function (err, data) {
     try {
       if (data) {
@@ -205,7 +205,7 @@ MONGOSTORE.prototype.get = function (sid, cb) {
  */
 
 MONGOSTORE.prototype.set = function (sid, sess, cb) {
-  _default(cb);
+  cb = _default(cb);
   try {
     var update = {_id: sid, session: sess};
     if (sess && sess.cookie && sess.cookie.expires) {

--- a/lib/connect-mongodb.js
+++ b/lib/connect-mongodb.js
@@ -101,7 +101,8 @@ var MONGOSTORE = module.exports = function MongoStore(options) {
   options = options || {};
   
   var _db,
-  
+      _serverConfig,
+      
       _getCollection = function (_db) {
         _db.collection(options.collection || defaults.collection, function (err, col) {
           if (err) {
@@ -114,10 +115,12 @@ var MONGOSTORE = module.exports = function MongoStore(options) {
   
   // If options.serverConfig instance of either, true
   if ([mongo.Server, mongo.ServerPair, mongo.ServerCluster, mongo.ReplSetServers].some(function(i) { return options.serverConfig instanceof i; })) {
-    _db = new mongo.Db(options.dbname || defaults.dbname, options.serverConfig);
+    _serverConfig = options.serverConfig;
+    _db = new mongo.Db(options.dbname || defaults.dbname, _serverConfig);
   }
   
   if (options.handle instanceof mongo.Db) {
+    _serverConfig = options.handle.serverConfig;
     _db = options.handle;
   }
   
@@ -126,12 +129,14 @@ var MONGOSTORE = module.exports = function MongoStore(options) {
         _details = parseConnectionURL(_url); // mongodb 0.7.9 parser is broken, this fixes it
       
     if (!_details.length) {
-      _db = new mongo.Db(_details.dbname, new mongo.Server(_details.host, _details.port, options));
+      _serverConfig = new mongo.Server(_details.host, _details.port, options);
+      _db = new mongo.Db(_details.dbname, _serverConfig);
     } else {
       for (i = 0, len = _details.length; i < len; i++) {
         servers.push(new mongo.Server(_details[i].host, _details[i].port, {}));
       }
-      _db = new mongo.Db(_details[0].dbname, new mongo.ReplSetServers(servers));
+      _serverConfig = new mongo.ReplSetServers(servers);
+      _db = new mongo.Db(_details[0].dbname, _serverConfig);
     }
   }
   
@@ -143,12 +148,12 @@ var MONGOSTORE = module.exports = function MongoStore(options) {
     }, options.reapInterval || 60 * 1000, this); // defaults to each minute
   }
   
-  if (_db.serverConfig && !_db.serverConfig.isConnected()) {
-    _db.open(function (err) {
+  if(!_serverConfig.isConnected()) {
+    _serverConfig.connect(function(err) {
       if (err) {
         throw Error("Error connecting to " + _url + " (" + (err instanceof Error ? err.message : err) + ")");
       }
-
+      
       if (_details.username && _details.password) {
         _db.authenticate(_details.username, _details.password, function () {
           _getCollection(_db);
@@ -156,7 +161,8 @@ var MONGOSTORE = module.exports = function MongoStore(options) {
       } else {
         _getCollection(_db);
       }
-    });
+      
+    })
   } else {
     _getCollection(_db);
   }

--- a/lib/connect-mongodb.js
+++ b/lib/connect-mongodb.js
@@ -18,8 +18,8 @@ var Store = require('connect').session.Store,
 
     getConnectionURL = function (options) {
       var url = '',
-          hosts = !options.host ? [defaults.host] : 'object' === typeof options.host ? options.host : [options.host],
-          ports = !options.port ? [defaults.port] : 'object' === typeof options.port ? options.port : [options.port],
+          hosts = (Array.isArray(options.host) ? options.host : [options.host]) || defaults.host,
+          ports = (Array.isArray(options.port) ? options.port : [options.port]) || defaults.port,
           username = options.username || '',
           password = options.password || '',
           userpass = '',

--- a/lib/connect-mongodb.js
+++ b/lib/connect-mongodb.js
@@ -98,13 +98,10 @@ var Store = require('connect').session.Store,
  */
 
 var MONGOSTORE = module.exports = function MongoStore(options) {
-
   options = options || {};
-
-  var _url = getConnectionURL(options),
-      _details = parseConnectionURL(_url), // mongodb 0.7.9 parser is broken, this fixes it
-      _db,
-
+  
+  var _db,
+  
       _getCollection = function (_db) {
         _db.collection(options.collection || defaults.collection, function (err, col) {
           if (err) {
@@ -114,37 +111,56 @@ var MONGOSTORE = module.exports = function MongoStore(options) {
         });
       },
       servers = [], i, len;
-
-  if (!_details.length) {
-    _db = new mongo.Db(_details.dbname, new mongo.Server(_details.host, _details.port, options));
-  } else {
-    for (i = 0, len = _details.length; i < len; i++) {
-      servers.push(new mongo.Server(_details[i].host, _details[i].port, {}));
-    }
-    _db = new mongo.Db(_details[0].dbname, new mongo.ReplSetServers(servers));
+  
+  // If options.serverConfig instance of either, true
+  if ([mongo.Server, mongo.ServerPair, mongo.ServerCluster, mongo.ReplSetServers].some(function(i) { return options.serverConfig instanceof i; })) {
+    _db = new mongo.Db(options.dbname || defaults.dbname, options.serverConfig);
   }
-
+  
+  if (options.handle instanceof mongo.Db) {
+    _db = options.handle;
+  }
+  
+  if (!_db) {
+    var _url = getConnectionURL(options),
+        _details = parseConnectionURL(_url); // mongodb 0.7.9 parser is broken, this fixes it
+      
+    if (!_details.length) {
+      _db = new mongo.Db(_details.dbname, new mongo.Server(_details.host, _details.port, options));
+    } else {
+      for (i = 0, len = _details.length; i < len; i++) {
+        servers.push(new mongo.Server(_details[i].host, _details[i].port, {}));
+      }
+      _db = new mongo.Db(_details[0].dbname, new mongo.ReplSetServers(servers));
+    }
+  }
+  
   Store.call(this, options);
-
+  
   if (options.reapInterval !== -1) {
     setInterval(function () {
       _collection.remove({expires: {'$lte': Date.now()}}, function () { });
     }, options.reapInterval || 60 * 1000, this); // defaults to each minute
   }
+  
+  if (_db.serverConfig && !_db.serverConfig.isConnected()) {
+    _db.open(function (err) {
+      if (err) {
+        throw Error("Error connecting to " + _url + " (" + (err instanceof Error ? err.message : err) + ")");
+      }
 
-  _db.open(function (err) {
-    if (err) {
-      throw Error("Error connecting to " + _url);
-    }
-
-    if (_details.username && _details.password) {
-      _db.authenticate(_details.username, _details.password, function () {
+      if (_details.username && _details.password) {
+        _db.authenticate(_details.username, _details.password, function () {
+          _getCollection(_db);
+        });
+      } else {
         _getCollection(_db);
-      });
-    } else {
-      _getCollection(_db);
-    }
-  });
+      }
+    });
+  } else {
+    _getCollection(_db);
+  }
+  
 };
 
 MONGOSTORE.prototype.__proto__ = Store.prototype;


### PR DESCRIPTION
Hello,

Here are some commits that will enable reusing of an existing connection or server configuration instead of forcing the opening of a new one. Also added corresponding information in the readme. I would have added some tests too but the tests in the repository were removed in 217cc3aa6f4e79e8f05011e11d593c4c1d02615d (mistake?!). 

Also I believe that the existing ad hoc implementation of Replica Sets should be removed: a user intending to use an adanced MongoDB configuration should be prepared to setup the appropriate connection using christkv/node-mongodb-native anyway. Besides, it seems reasonable that such a user has done that setup already. I would have done it but I'm floating it for discussion here first.
