### PR TITLE
Fix connect sessions.

### DIFF
--- a/lib/connect-mongodb.js
+++ b/lib/connect-mongodb.js
@@ -158,7 +158,7 @@ MONGOSTORE.prototype.get = function (sid, cb) {
   _collection.findOne({_id: sid}, function (err, data) {
     try {
       if (data) {
-        cb(null, data.session);
+        cb(null, JSON.parse(data.session.toString()));
       } else {
         cb();
       }
@@ -181,7 +181,7 @@ MONGOSTORE.prototype.get = function (sid, cb) {
 MONGOSTORE.prototype.set = function (sid, sess, cb) {
   _default(cb);
   try {
-    var update = {_id: sid, session: sess};
+    var update = {_id: sid, session: JSON.stringify(sess)};
     if (sess && sess.cookie && sess.cookie.expires) {
       update.expires = Date.parse(sess.cookie.expires);
     }


### PR DESCRIPTION
Before 0.4.0, sessions were stored in the DB as JSON strings.
As of 0.4.0, they were stored as objects rather than strings, but
the result of get() was a non-modifiable object, so it both broke
backwards compatibility, and broke some connect-session assumptions.
Revert to the pre-0.4.0 approach to fix both problems.

NOTE: I can't easily test this against HEAD, because it introduces dependencies on a newer mongodb module.  If this is a problem, let me know.
