### PR TITLE
Fix connect sessions.

### DIFF
--- a/lib/connect-mongodb.js
+++ b/lib/connect-mongodb.js
@@ -158,7 +158,13 @@ MONGOSTORE.prototype.get = function (sid, cb) {
   _collection.findOne({_id: sid}, function (err, data) {
     try {
       if (data) {
-        cb(null, data.session);
+        // Old versions of this code used to store sessions in the database
+        // as a JSON string rather than as a structure.  For backwards
+        // compatibility, handle old sessions.
+        var sess =
+            'string' === typeof data.session ? JSON.parse(data.session)
+                                             : data.session;
+        cb(null, sess);
       } else {
         cb();
       }
@@ -181,7 +187,10 @@ MONGOSTORE.prototype.get = function (sid, cb) {
 MONGOSTORE.prototype.set = function (sid, sess, cb) {
   _default(cb);
   try {
-    var update = {_id: sid, session: sess};
+    // With connect-session, sess.cookie has a getter .data, and if we
+    // store sess.cookie.data in the DB, problems occur.  Run sess through
+    // JSON.stringify(), which strips out the getter.
+    var update = {_id: sid, session: JSON.parse(JSON.stringify(sess))};
     if (sess && sess.cookie && sess.cookie.expires) {
       update.expires = Date.parse(sess.cookie.expires);
     }


### PR DESCRIPTION
A better approach to https://github.com/masylum/connect-mongodb/pull/24

Before 0.4.0, sessions were stored in the DB as JSON strings.
As of 0.4.0, they were stored as objects rather than strings, but
the connect-session cookie.data getter results were stored, breaking
a connect-session assumption.

In this version, we use JSON.parse(JSON.stringify()) on the session
data to avoid storing the .data getter results.  We also detect
whether a session in the DB is a string, and if so parse it as JSON,
for backwards compatibility with pre-0.4.0 databases.
