### PR TITLE
Support passing a URL option.

### DIFF
--- a/lib/connect-mongodb.js
+++ b/lib/connect-mongodb.js
@@ -25,7 +25,7 @@ var MONGOSTORE = module.exports = function MongoStore(options, callback) {
   options = options || {};
   callback = _default(callback);
 
-  var db, server_config;
+  var db, server_config, url, auth;
 
   function getCollection(db, callback) {
     db.collection(options.collection || _defaults.collection, function (err, col) {
@@ -43,6 +43,20 @@ var MONGOSTORE = module.exports = function MongoStore(options, callback) {
     } else {
       getCollection(db, callback);
     }
+  }
+
+  if (options.url) {
+    url = require('url').parse(options.url);
+
+    if (url.auth) {
+      auth = url.auth.split(':', 2);
+      options.username = auth[0];
+      options.password = auth[1];
+    }
+
+    options.db = new mongo.Db(url.pathname.replace(/^\//, ''),
+                              new mongo.Server(url.hostname || _defaults.host,
+                                               url.port || _defaults.port));
   }
 
   if (options.server_config) {

--- a/tests/core.js
+++ b/tests/core.js
@@ -4,6 +4,7 @@ var testosterone = require('testosterone')({title: 'models/advertiser'})
   , Db = require('mongodb').Db
   , Server = require('mongodb').Server
   , server_config = new Server('localhost', 27017, {auto_reconnect: true, native_parser: true})
+  , url = 'mongodb://localhost:27017/test'
   , db = new Db('test', server_config, {});
 
 testosterone
@@ -16,6 +17,7 @@ testosterone
       require('..')({db: null}, funk.add(assert.ok));
       require('..')({db: db, setInterval: -1}, funk.add(assert.ifError));
       require('..')({server_config: server_config, setInterval: -1}, funk.add(assert.ifError));
+      require('..')({url: url, setInterval: -1}, funk.add(assert.ifError));
       funk.run(done);
     });
   })


### PR DESCRIPTION
Similar to passing in a dbname and server config (and auth info), but
way more compact and handy. Creates its own connection.

Plays way better with Mongoose, since it doesn't really like to share its db connection and is already configured with a URL.
