### PR TITLE
Issue with storing session objects rather than as, say, JSON string.

### DIFF
--- a/lib/connect-mongodb.js
+++ b/lib/connect-mongodb.js
@@ -138,7 +138,7 @@ MONGOSTORE.prototype.get = function (sid, cb) {
 MONGOSTORE.prototype.set = function (sid, sess, cb) {
   cb = _default(cb);
   try {
-    var update = {_id: sid, session: JSON.parse(JSON.stringify(sess))};
+    var update = {_id: sid, session: /*JSON.parse*/(JSON.stringify(sess))};
     if (sess && sess.cookie && sess.cookie.expires) {
       update.expires = Date.parse(sess.cookie.expires);
     }


### PR DESCRIPTION
Hi, not sure if there's another way around this problem, or if it's due to the combination of module versions I'm using. I ran into issues with the session being stored as an object in mongodb since it stores the session cookie field originalMaxAge as NumberLong, and the mongodb module I'm using returns this as an object in the JS value, but then connect's maxAge setter gets confused since it's looking for a number type. So, I had to switch to storing the sessions as JSON strings (like the connect-redis module).
