### PR TITLE
Update the mongodb and connect dependency specification.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Vladimir Dronnikov <dronnikov@gmail.com>",
   "contributors": ["Pau Ramon <masylum@gmail.com>", "ramv"],
   "repository": {"type": "git", "url": "git://github.com/masylum/connect-mongodb.git"},
-  "dependencies": {"mongodb": "1.0.2", "connect": "1.8.5"},
+  "dependencies": {"mongodb": "1.x", "connect": ">=1.8.5 <2"},
   "devDependencies": {"testosterone": "1.2.0", "gently": "0.9.1", "funk": "1.5.0"},
   "main": "./lib/connect-mongodb"
 }


### PR DESCRIPTION
This change allows minor version updates to both the mongodb driver and the connect library. I ran into dependency conflicts between the mongoose library and the connect-mongodb where the version of the mongodb driver is an older release.
